### PR TITLE
Add initial README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,7 @@
 You can quickly start working with it by following these steps:
 
 1. [Install jbang](https://www.jbang.dev/download/)
-2. Create `heylogs.java`
-
-    ```java
-    ///usr/bin/env jbang "$0" "$@" ; exit $?
-
-    //DEPS com.github.nbbrd.heylogs:heylogs-cli:0.6.0
-
-    public class heylogs {
-    public static void main(String... args) {
-        nbbrd.heylogs.cli.HeylogsCommand.main(args);
-        }
-    }
-    ```
-
+2. Download [`heylogs.java`](heylogs.java)
 3. Execute `jbang heylogs.java`
+
+On linux, you can make `heylogs.java` executable and place it in `/usr/local/bin`. Then it is directly available at the command line.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # heylogs
 
-`heylogs` is a set of tools to deal with the keep-a-changelog format.
+`heylogs` is a set of tools to deal with the [keep-a-changelog format](https://keepachangelog.com).
+
+## Installation
 
 You can quickly start working with it by following these steps:
 
@@ -9,3 +11,5 @@ You can quickly start working with it by following these steps:
 
 On linux, you can download `heylogs.java`, flag it as executable, rename it to `heylogs`, and place it in `/usr/local/bin`.
 Then it is directly available at the command line as `heylogs`.
+
+On Windows, you can alternatively use [Scoop](https://scoop.sh/) to install it. See <https://github.com/nbbrd/scoop-nbbrd> for details.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 You can quickly start working with it by following these steps:
 
 1. [Install jbang](https://www.jbang.dev/download/)
-2. Download [`heylogs.java`](heylogs.java)
+2. Download [`heylogs.java`](https://github.com/nbbrd/jbang-catalog/blob/master/heylogs.java) - provided by [jbang-catalog](https://github.com/nbbrd/jbang-catalog/tree/master)
 3. Execute `jbang heylogs.java`
 
 On linux, you can make `heylogs.java` executable and place it in `/usr/local/bin`. Then it is directly available at the command line.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 You can quickly start working with it by following these steps:
 
 1. [Install jbang](https://www.jbang.dev/download/)
-2. Download [`heylogs.java`](https://github.com/nbbrd/jbang-catalog/blob/master/heylogs.java) - provided by [jbang-catalog](https://github.com/nbbrd/jbang-catalog/tree/master)
-3. Execute `jbang heylogs.java`
+3. Execute `jbang https://raw.githubusercontent.com/nbbrd/jbang-catalog/master/heylogs.java check `
 
-On linux, you can make `heylogs.java` executable and place it in `/usr/local/bin`. Then it is directly available at the command line.
+On linux, you can download `heylogs.java`, flag it as executable, rename it to `heylogs`, and place it in `/usr/local/bin`.
+Then it is directly available at the command line as `heylogs`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# heylogs
+
+`heylogs` is a set of tools to deal with the keep-a-changelog format.
+
+You can quickly start working with it by following these steps:
+
+1. [Install jbang](https://www.jbang.dev/download/)
+2. Create `heylogs.java`
+
+    ```java
+    ///usr/bin/env jbang "$0" "$@" ; exit $?
+
+    //DEPS com.github.nbbrd.heylogs:heylogs-cli:0.6.0
+
+    public class heylogs {
+    public static void main(String... args) {
+        nbbrd.heylogs.cli.HeylogsCommand.main(args);
+        }
+    }
+    ```
+
+3. Execute `jbang heylogs.java`

--- a/heylogs.java
+++ b/heylogs.java
@@ -1,9 +1,0 @@
-///usr/bin/env jbang "$0" "$@" ; exit $?
-
-//DEPS com.github.nbbrd.heylogs:heylogs-cli:0.6.0
-
-public class heylogs {
-    public static void main(String... args) {
-        nbbrd.heylogs.cli.HeylogsCommand.main(args);
-    }
-}

--- a/heylogs.java
+++ b/heylogs.java
@@ -1,0 +1,9 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+
+//DEPS com.github.nbbrd.heylogs:heylogs-cli:0.6.0
+
+public class heylogs {
+    public static void main(String... args) {
+        nbbrd.heylogs.cli.HeylogsCommand.main(args);
+    }
+}


### PR DESCRIPTION
I did not find information on how to use this tool. I very much like [jbang](https://www.jbang.dev/), because it frees the user of installing a JRE. Therefore, I added some quick steps in the README.md.

~~I thought whether it would be good to have the calling Java file in the `README.md` or at the root of the repository (to have it directly available for the end user). I opted for the latter.~~

**Update** I found https://github.com/nbbrd/jbang-catalog/tree/master and linked the file available there.
