### PR TITLE
Add support for en ("–") and em dashes ("—") as separator between version and date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- The en dash ("–") is also supported as separator between version and date
+- The en ("–") and em dashes ("") are also supported as separator between version and date
 
 ## [0.6.0] - 2023-06-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- The en dash ("–") is also supported as separator between version and date
+
 ## [0.6.0] - 2023-06-20
 
 This release improves extension points and also aligns features of Maven plugin and CLI.

--- a/heylogs-api/src/main/java/nbbrd/heylogs/Version.java
+++ b/heylogs-api/src/main/java/nbbrd/heylogs/Version.java
@@ -97,8 +97,8 @@ public class Version implements BaseSection {
         BasedSequence date = secondPart.getChars();
 
         BasedSequence trimmedStart = date.trimStart();
-        // The unicode en dash ("–") is also accepted as separator
-        if (!trimmedStart.startsWith("-") && !trimmedStart.startsWith("–")) {
+        // The unicode en dash ("–") and em dash ("—") are also accepted as separators
+        if (!trimmedStart.startsWith("-") && !trimmedStart.startsWith("–") && !trimmedStart.startsWith("—")) {
             throw new IllegalArgumentException("Missing date prefix");
         }
 

--- a/heylogs-api/src/main/java/nbbrd/heylogs/Version.java
+++ b/heylogs-api/src/main/java/nbbrd/heylogs/Version.java
@@ -96,7 +96,9 @@ public class Version implements BaseSection {
     private static LocalDate parseDate(Node secondPart) throws IllegalArgumentException {
         BasedSequence date = secondPart.getChars();
 
-        if (!date.trimStart().startsWith("-")) {
+        BasedSequence trimmedStart = date.trimStart();
+        // The unicode en dash ("–") is also accepted as separator
+        if (!trimmedStart.startsWith("-") && !trimmedStart.startsWith("–")) {
             throw new IllegalArgumentException("Missing date prefix");
         }
 

--- a/heylogs-api/src/test/java/nbbrd/heylogs/VersionTest.java
+++ b/heylogs-api/src/test/java/nbbrd/heylogs/VersionTest.java
@@ -32,6 +32,10 @@ public class VersionTest {
         assertThat(parse(asHeading("## [1.1.0] - 2019-02-15")))
                 .isEqualTo(Version.of("1.1.0", d20190215));
 
+        // Unicode en dash as separator
+        assertThat(parse(asHeading("## [1.1.0] – 2019-02-15")))
+                .isEqualTo(Version.of("1.1.0", d20190215));
+
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> parse(asHeading("# [1.1.0] - 2019-02-15")))
                 .withMessageContaining("Invalid heading level");

--- a/heylogs-api/src/test/java/nbbrd/heylogs/VersionTest.java
+++ b/heylogs-api/src/test/java/nbbrd/heylogs/VersionTest.java
@@ -36,6 +36,10 @@ public class VersionTest {
         assertThat(parse(asHeading("## [1.1.0] – 2019-02-15")))
                 .isEqualTo(Version.of("1.1.0", d20190215));
 
+        // Unicode em dash as separator
+        assertThat(parse(asHeading("## [1.1.0] — 2019-02-15")))
+                .isEqualTo(Version.of("1.1.0", d20190215));
+
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> parse(asHeading("# [1.1.0] - 2019-02-15")))
                 .withMessageContaining("Invalid heading level");


### PR DESCRIPTION
I very much like to use an en dash to separate version and date. I know that typography demands an em dash (see e.g., https://www.quora.com/Would-it-be-correct-to-use-an-en-dash-to-separate-section-number-and-title-2-3-Forest-Wildlife-or-would-an-em-dash-be-more-appropriate), but that dash was too large for me.

I also added support for em dash.

On the one hand, a CHANGELOG should be easily parsable. On the other hand, it should look nice for end users. A changelog should be more read than created. Thus, the toolings for handling might have more effort - than causing typography irritation at the readers.

