### PR TITLE
Change `entry-for-every-versions` to `all-h2-contain-a-version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Renamed rule `entry-for-every-versions` to `all-h2-contain-a-version`
+
 ## [0.6.0] - 2023-06-20
 
 This release improves extension points and also aligns features of Maven plugin and CLI.

--- a/heylogs-api/src/main/java/internal/heylogs/GuidingPrinciples.java
+++ b/heylogs-api/src/main/java/internal/heylogs/GuidingPrinciples.java
@@ -26,10 +26,10 @@ public enum GuidingPrinciples implements Rule {
             return node instanceof Document ? validateForHumans((Document) node) : NO_PROBLEM;
         }
     },
-    ENTRY_FOR_EVERY_VERSIONS {
+    ALL_H2_CONTAIN_A_VERSION {
         @Override
         public Failure validate(@NotNull Node node) {
-            return node instanceof Heading ? validateEntryForEveryVersions((Heading) node) : NO_PROBLEM;
+            return node instanceof Heading ? validateAllH2ContainAVersion((Heading) node) : NO_PROBLEM;
         }
     },
     TYPE_OF_CHANGES_GROUPED {
@@ -105,7 +105,7 @@ public enum GuidingPrinciples implements Rule {
     }
 
     @VisibleForTesting
-    static Failure validateEntryForEveryVersions(@NotNull Heading heading) {
+    static Failure validateAllH2ContainAVersion(@NotNull Heading heading) {
         if (!Version.isVersionLevel(heading)) {
             return NO_PROBLEM;
         }
@@ -114,7 +114,7 @@ public enum GuidingPrinciples implements Rule {
         } catch (IllegalArgumentException ex) {
             return Failure
                     .builder()
-                    .rule(ENTRY_FOR_EVERY_VERSIONS)
+                    .rule(ALL_H2_CONTAIN_A_VERSION)
                     .message(ex.getMessage())
                     .location(heading)
                     .build();

--- a/heylogs-api/src/test/java/internal/heylogs/GuidingPrinciplesTest.java
+++ b/heylogs-api/src/test/java/internal/heylogs/GuidingPrinciplesTest.java
@@ -42,18 +42,18 @@ public class GuidingPrinciplesTest {
     @Test
     public void testValidateEntryForEveryVersions() {
         assertThat(of(Heading.class).descendants(using("/Main.md")))
-                .map(GuidingPrinciples::validateEntryForEveryVersions)
+                .map(GuidingPrinciples::validateAllH2ContainAVersion)
                 .isNotEmpty()
                 .filteredOn(Objects::nonNull)
                 .isEmpty();
 
         assertThat(of(Heading.class).descendants(using("/InvalidVersion.md")))
-                .map(GuidingPrinciples::validateEntryForEveryVersions)
+                .map(GuidingPrinciples::validateAllH2ContainAVersion)
                 .isNotEmpty()
                 .filteredOn(Objects::nonNull)
-                .contains(Failure.builder().rule(ENTRY_FOR_EVERY_VERSIONS).message("Invalid date format").line(2).column(1).build(), atIndex(0))
-                .contains(Failure.builder().rule(ENTRY_FOR_EVERY_VERSIONS).message("Missing date part").line(3).column(1).build(), atIndex(1))
-                .contains(Failure.builder().rule(ENTRY_FOR_EVERY_VERSIONS).message("Missing ref link").line(4).column(1).build(), atIndex(2))
+                .contains(Failure.builder().rule(ALL_H2_CONTAIN_A_VERSION).message("Invalid date format").line(2).column(1).build(), atIndex(0))
+                .contains(Failure.builder().rule(ALL_H2_CONTAIN_A_VERSION).message("Missing date part").line(3).column(1).build(), atIndex(1))
+                .contains(Failure.builder().rule(ALL_H2_CONTAIN_A_VERSION).message("Missing ref link").line(4).column(1).build(), atIndex(2))
                 .hasSize(3);
 
     }


### PR DESCRIPTION
I found the name `entry-for-every-versions` misleading. My English grammer gut feeling says it should be `each version` (each - and no plurarl versions).

However, the test itself checks h2 levels only. I wanted to make that explicit.