### PR TITLE
Enable checking git diffs for modifying "frozen" areas

### DIFF
--- a/.github/workflows/java-maven.yml
+++ b/.github/workflows/java-maven.yml
@@ -1,4 +1,4 @@
-name: Java8+ with Maven
+name: Java LTS with Maven
 
 on: [ push, pull_request ]
 
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 17 ]
+        java: [ 17 ]
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
 
     name: JDK${{ matrix.java }} on ${{ matrix.os }}
@@ -38,7 +38,7 @@ jobs:
     if: startsWith(github.repository, 'nbbrd/') && startsWith(github.ref, 'refs/heads/develop')
     strategy:
       matrix:
-        java: [ 17 ]
+        java: [ 11, 17 ]
         os: [ ubuntu-latest ]
 
     name: Snapshot on develop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Added support for checking git diffs for touching released versions. Use `-g` at the command line.
 - The en ("–") and em dashes ("") are also supported as separator between version and date
 
 ### Changed
 
 - Renamed rule `entry-for-every-versions` to `all-h2-contain-a-version`
+- Minimum Java requirement is now Java 11 (due to the dependency on [Eclipse JGit](https://eclipse.dev/jgit/))
 
 ## [0.6.0] - 2023-06-20
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It can be used as a linter in interactive sessions and automations.
 Key points:
 
 - Available as a library, a [command-line tool](#installation) and a [Maven plugin](#maven-plugin)
-- Java 8 minimum requirement
+- Java 11 minimum requirement
 
 Features:
 
@@ -17,11 +17,18 @@ Features:
 - Checks format
 - Extracts versions
 
+The `check` feature also contains a check if during an update of the CHANGELOG.md file, areas of released versions are touched.
+For instance, a contributor starts a pull request and adds their change to CHANGELOG.md.
+Then, the main branch is released.
+Now, the PR should move the changelog entry to the new `[unreleased]` section.
+Therefore, `heylogs` warns in case there are modifications inside blocks of released versions.
+One has to enable this check explicitly by the `-g` command line parameter.
+
 ## Command-line tool
 
 Heylogs CLI runs on any desktop operating system such as Microsoft Windows, 
 Solaris OS, Apple macOS, Ubuntu and other various Linux distributions. 
-It requires a Java SE Runtime Environment (JRE) version 8 or later to run on such as OpenJDK.
+It requires a Java SE Runtime Environment (JRE) version 11 or later to run on such as OpenJDK.
 
 ### Installation
 
@@ -165,7 +172,7 @@ The following script extract the latest version from the changelog for a release
 ## Developing
 
 This project is written in Java and uses [Apache Maven](https://maven.apache.org/) as a build tool.  
-It requires [Java 8 as minimum version](https://whichjdk.com/) and all its dependencies are hosted
+It requires [Java 11 as minimum version](https://whichjdk.com/) and all its dependencies are hosted
 on [Maven Central](https://search.maven.org/).
 
 The code can be build using any IDE or by just type-in the following commands in a terminal:

--- a/heylogs-api/pom.xml
+++ b/heylogs-api/pom.xml
@@ -57,6 +57,32 @@
             <artifactId>java-io-base</artifactId>
             <version>0.0.25</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>6.7.0.202309050840-r</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jooq</groupId>
+            <artifactId>jool</artifactId>
+            <version>0.9.15</version>
+        </dependency>
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>tinylog-api</artifactId>
+        </dependency>
+        <!-- required for jgit -->
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>slf4j-tinylog</artifactId>
+            <version>2.6.2</version>
+        </dependency>
 
         <!-- test only -->
         <dependency>
@@ -67,6 +93,12 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>tinylog-impl</artifactId>
+            <version>${tinylog.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/heylogs-api/src/main/java/internal/heylogs/GitDiffRule.java
+++ b/heylogs-api/src/main/java/internal/heylogs/GitDiffRule.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
@@ -312,7 +313,7 @@ public final class GitDiffRule implements Rule {
         Parser parser = Parser.builder().build();
         Document document;
         try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
-             InputStreamReader inputStreamReader = new InputStreamReader(byteArrayInputStream)) {
+             InputStreamReader inputStreamReader = new InputStreamReader(byteArrayInputStream, StandardCharsets.UTF_8)) {
             document = parser.parseReader(inputStreamReader);
         }
         ReversiblePeekingIterator<Node> iterator = document.getChildren().iterator();

--- a/heylogs-api/src/main/java/internal/heylogs/GitDiffRule.java
+++ b/heylogs-api/src/main/java/internal/heylogs/GitDiffRule.java
@@ -108,7 +108,7 @@ public final class GitDiffRule implements Rule {
      */
     public void setPath(Path path) {
         if (path == null) {
-            java.util.logging.Logger.getLogger(GitDiffRule.class.getCanonicalName()).log(Level.WARNING, "null was passed");
+            Logger.warn("null was passed");
             return;
         }
         if (path.equals(this.path)) {
@@ -240,8 +240,14 @@ public final class GitDiffRule implements Rule {
             ObjectId newObjectId;
             if (useHeadAndParent) {
                 newObjectId = repository.resolve(Constants.HEAD);
+                if (newObjectId == null) {
+                    throw new IllegalArgumentException("HEAD not found in repository");
+                }
             } else {
                 newObjectId = repository.resolve(newRevStr);
+                if (newObjectId == null) {
+                    throw new IllegalArgumentException("Reference " + newRevStr + " not found in repository");
+                }
             }
             RevCommit commit = revWalk.parseCommit(newObjectId);
             RevCommit oldCommit;

--- a/heylogs-api/src/main/java/internal/heylogs/GitDiffRule.java
+++ b/heylogs-api/src/main/java/internal/heylogs/GitDiffRule.java
@@ -1,0 +1,336 @@
+package internal.heylogs;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.vladsch.flexmark.ast.Heading;
+import com.vladsch.flexmark.ast.Reference;
+import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.util.ast.Document;
+import com.vladsch.flexmark.util.ast.Node;
+import com.vladsch.flexmark.util.collection.iteration.ReversiblePeekingIterator;
+import com.vladsch.flexmark.util.misc.Pair;
+import nbbrd.design.VisibleForTesting;
+import nbbrd.heylogs.Failure;
+import nbbrd.heylogs.Version;
+import nbbrd.heylogs.spi.Rule;
+import nbbrd.service.ServiceProvider;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.diff.DiffEntry;
+import org.eclipse.jgit.diff.DiffFormatter;
+import org.eclipse.jgit.errors.RepositoryNotFoundException;
+import org.eclipse.jgit.lib.Config;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectLoader;
+import org.eclipse.jgit.lib.ObjectReader;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevTree;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.eclipse.jgit.treewalk.CanonicalTreeParser;
+import org.eclipse.jgit.treewalk.TreeWalk;
+import org.eclipse.jgit.treewalk.filter.PathFilter;
+import org.eclipse.jgit.util.io.DisabledOutputStream;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jooq.lambda.Unchecked;
+import org.tinylog.Logger;
+
+@ServiceProvider
+public final class GitDiffRule implements Rule {
+
+    private Path path;
+
+    private String oldRevStr;
+    private String newRevStr;
+    private boolean useHeadAndParent = true;
+
+    private List<Pair<Integer, Integer>> commitModificationRanges;
+
+    private Set<Failure> reported;
+    private boolean isGitRepository;
+    private boolean initialized;
+    private boolean processedReference;
+    private Version latestFrozenVersion;
+    private boolean latestFrozenVersionSeen;
+    private Heading previousFrozenHeading;
+    // the first link to a Diff (at the end of CHANGELOG.md)
+    private Node firstReference;
+
+    public GitDiffRule() {
+        resetFields();
+        useHeadAndParent = true;
+    }
+
+    public GitDiffRule(String oldRevStr, String newRevStr) {
+        resetFields();
+        useHeadAndParent = false;
+        this.oldRevStr = oldRevStr;
+        this.newRevStr = newRevStr;
+    }
+
+    @VisibleForTesting
+    GitDiffRule(Path path) {
+        resetFields();
+        this.path = path;
+    }
+
+    public void resetFields() {
+        this.reported = new HashSet<>();
+        this.isGitRepository = true;
+        this.initialized = false;
+        this.processedReference = false;
+        this.latestFrozenVersion = null;
+        this.latestFrozenVersionSeen = false;
+        this.previousFrozenHeading = null;
+        this.firstReference = null;
+    }
+
+    /**
+     * <p>
+     *     Changes the underlying git repository.
+     * </p>
+     * <p>
+     *     Normally, one would re-instantiate the class. The current infrastructure, however, demands that each check is initialized once.
+     * </p>
+     */
+    public void setPath(Path path) {
+        if (path.equals(this.path)) {
+            return;
+        }
+        resetFields();
+        this.path = path;
+    }
+
+    @Override
+    public @NotNull String getId() {
+        return "releasechangesfrozen";
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return Rule.isEnabled(System.getProperties(), getId());
+    }
+
+    @Override
+    public Failure validate(@NotNull Node node) {
+        if (!isGitRepository || processedReference) {
+            return NO_PROBLEM;
+        }
+        if (!initialized) {
+            initialize(node);
+            return NO_PROBLEM;
+        }
+        if (node == firstReference) {
+            processedReference = true;
+            if (previousFrozenHeading == null) {
+                return NO_PROBLEM;
+            }
+            return getFailure(previousFrozenHeading, node.getLineNumber());
+        }
+        if (!(node instanceof Heading)) {
+            return NO_PROBLEM;
+        }
+        Heading heading = (Heading) node;
+        if (!Version.isVersionLevel(heading)) {
+            return NO_PROBLEM;
+        }
+        Version version;
+        try {
+            version = Version.parse(heading);
+        } catch (IllegalArgumentException e) {
+            Logger.debug("Ignoring invalid version at {}", heading);
+            return NO_PROBLEM;
+        }
+        if (version.isUnreleased()) {
+            return NO_PROBLEM;
+        }
+        if (!latestFrozenVersionSeen) {
+            if (!version.equals(latestFrozenVersion)) {
+                return NO_PROBLEM;
+            }
+            latestFrozenVersionSeen = true;
+        }
+        Failure result;
+        if (previousFrozenHeading == null) {
+            result = NO_PROBLEM;
+        } else {
+            result = getFailure(previousFrozenHeading, heading.getLineNumber());
+        }
+        previousFrozenHeading = heading;
+        return result;
+    }
+
+    @Nullable
+    private void initialize(@NotNull Node node) {
+        initialized = true;
+        try {
+            initialize();
+        } catch (RepositoryNotFoundException e) {
+            Logger.debug("No git repository found");
+            isGitRepository = false;
+        } catch (Exception e) {
+            Logger.error("Could not read from git repository", e);
+            isGitRepository = false;
+        }
+        // Set {@link #firstReference} to the first reference in the reference list at the bottom
+        // We just ignore link updates
+        ReversiblePeekingIterator<Node> iterator = node.getDocument().getReversedChildIterator();
+        Node previous = iterator.next();
+        do {
+            firstReference = previous;
+            previous = iterator.next();
+        } while (iterator.hasNext() && (previous instanceof Reference));
+    }
+
+    private Failure getFailure(@NotNull Heading heading, int nextHeadingLineNumber) {
+        int lineNumber = heading.getLineNumber();
+        Optional<Integer> firstModifiedLineNumber = intersects(lineNumber, nextHeadingLineNumber - 1);
+        if (firstModifiedLineNumber.isEmpty()) {
+            return NO_PROBLEM;
+        }
+        Failure result = Failure.builder()
+                                .rule(this)
+                                .location(heading)
+                                .line(firstModifiedLineNumber.get() + 1)
+                                .message("Change in a released version")
+                                .build();
+        if (reported.contains(result)) {
+            return NO_PROBLEM;
+        }
+        reported.add(result);
+        return result;
+    }
+
+    private Optional<Integer> intersects(int start, int end) {
+        return commitModificationRanges
+                .stream()
+                .filter(pair -> {
+                    int first = pair.getFirst();
+                    int second = pair.getSecond();
+                    return start <= second && end >= first; // this checks for overlapping ranges
+                }).findAny()
+                .map(pair -> pair.getFirst());
+    }
+
+    @VisibleForTesting
+    void initialize() throws Exception {
+        FileRepositoryBuilder builder = new FileRepositoryBuilder();
+        try (Repository repository = builder.setGitDir(path.resolve(".git").toFile())
+                                            .readEnvironment()
+                                            .findGitDir()
+                                            .build();
+             RevWalk revWalk = new RevWalk(repository)) {
+
+            ObjectId newObjectId;
+            if (useHeadAndParent) {
+                newObjectId = repository.resolve(Constants.HEAD);
+            } else {
+                newObjectId = repository.resolve(newRevStr);
+            }
+            RevCommit commit = revWalk.parseCommit(newObjectId);
+            RevCommit oldCommit;
+            if (useHeadAndParent) {
+                oldCommit = revWalk.parseCommit(commit.getParent(0));
+            } else {
+                oldCommit = revWalk.parseCommit(repository.resolve(oldRevStr));
+            }
+
+            this.commitModificationRanges = determineCommitModificationRanges(repository, oldCommit, commit);
+            setLatestFrozenVersion(repository, revWalk, oldCommit);
+        }
+    }
+
+    @VisibleForTesting
+    static List<Pair<Integer, Integer>> determineCommitModificationRanges(Repository repository, RevCommit oldCommit, RevCommit newCommit) throws IOException, GitAPIException {
+        final List<Pair<Integer, Integer>> commitVersionModificationRanges;
+        try (ObjectReader reader = repository.newObjectReader()) {
+            CanonicalTreeParser headTreeParser = new CanonicalTreeParser();
+            headTreeParser.reset(reader, newCommit.getTree().getId());
+            RevTree oldCommitTree = oldCommit.getTree();
+            CanonicalTreeParser parentTreeParser = new CanonicalTreeParser();
+            parentTreeParser.reset(reader, oldCommitTree.getId());
+            Git git = new Git(repository);
+            List<DiffEntry> diffs = git.diff()
+                                       .setOldTree(parentTreeParser)
+                                       .setNewTree(headTreeParser)
+                                       .call();
+            try (DiffFormatter formatter = new DiffFormatter(DisabledOutputStream.INSTANCE)) {
+                formatter.setReader(reader, new Config());
+                commitVersionModificationRanges =
+                        diffs.stream()
+                             .filter(entry -> entry.getNewPath().equals("CHANGELOG.md"))
+                             .map(Unchecked.function(entry -> formatter.toFileHeader(entry)))
+                             .flatMap(fileHeader -> fileHeader.toEditList().stream())
+                             .flatMap(edit -> {
+                                 switch (edit.getType()) {
+                                     case INSERT:
+                                     case REPLACE:
+                                         return Stream.of(new Pair<>(edit.getBeginB(), edit.getEndB() - 1));
+                                     case DELETE:
+                                         return Stream.of(new Pair<>(edit.getBeginB(), edit.getBeginB()));
+                                     default:
+                                         return Stream.empty();
+                                 }
+                             }).collect(Collectors.toList());
+            }
+        }
+        return commitVersionModificationRanges;
+    }
+
+    private void setLatestFrozenVersion(Repository repository, RevWalk revWalk, RevCommit commit) throws Exception {
+        RevTree tree = revWalk.parseCommit(commit).getTree();
+        try (TreeWalk treeWalk = new TreeWalk(repository)) {
+            treeWalk.addTree(tree);
+            treeWalk.setFilter(PathFilter.create("CHANGELOG.md"));
+            if (!treeWalk.next()) {
+                throw new FileNotFoundException("CHANGELOG.md not found");
+            }
+            ObjectId objectId = treeWalk.getObjectId(0);
+            ObjectLoader loader = repository.open(objectId);
+            this.latestFrozenVersion = getNewestRelease(loader.getBytes());
+            if (this.latestFrozenVersion == null) {
+                Logger.debug("No release found in CHANGELOG.md");
+            }
+        }
+    }
+
+    @VisibleForTesting
+    static @Nullable Version getNewestRelease(byte[] bytes) throws Exception {
+        Parser parser = Parser.builder().build();
+        Document document;
+        try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+             InputStreamReader inputStreamReader = new InputStreamReader(byteArrayInputStream)) {
+            document = parser.parseReader(inputStreamReader);
+        }
+        ReversiblePeekingIterator<Node> iterator = document.getChildren().iterator();
+        while (iterator.hasNext()) {
+            Node node = iterator.next();
+            if (!(node instanceof Heading)) {
+                continue;
+            }
+            Heading heading = (Heading) node;
+            if (!Version.isVersionLevel(heading)) {
+                continue;
+            }
+            Version version = Version.parse(heading);
+            if (version.isUnreleased()) {
+                continue;
+            }
+            return version;
+        }
+        return null;
+    }
+}

--- a/heylogs-api/src/main/java/internal/heylogs/GitDiffRule.java
+++ b/heylogs-api/src/main/java/internal/heylogs/GitDiffRule.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -106,6 +107,10 @@ public final class GitDiffRule implements Rule {
      * </p>
      */
     public void setPath(Path path) {
+        if (path == null) {
+            java.util.logging.Logger.getLogger(GitDiffRule.class.getCanonicalName()).log(Level.WARNING, "null was passed");
+            return;
+        }
         if (path.equals(this.path)) {
             return;
         }

--- a/heylogs-api/src/main/java/nbbrd/heylogs/Failure.java
+++ b/heylogs-api/src/main/java/nbbrd/heylogs/Failure.java
@@ -1,5 +1,7 @@
 package nbbrd.heylogs;
 
+import java.util.Objects;
+
 import com.vladsch.flexmark.util.ast.Node;
 import lombok.NonNull;
 import nbbrd.heylogs.spi.Rule;
@@ -28,5 +30,20 @@ public class Failure {
             return line(location.getStartLineNumber() + 1)
                     .column(location.lineColumnAtStart().getSecond() + 1);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Failure failure = (Failure) o;
+        return line == failure.line && column == failure.column && Objects.equals(ruleId, failure.ruleId) && Objects.equals(message, failure.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ruleId, message, line, column);
     }
 }

--- a/heylogs-api/src/main/java/nbbrd/heylogs/Version.java
+++ b/heylogs-api/src/main/java/nbbrd/heylogs/Version.java
@@ -13,12 +13,14 @@ import nbbrd.design.StaticFactoryMethod;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 import java.util.Iterator;
+import java.util.Objects;
 
 @lombok.Value(staticConstructor = "of")
 @RepresentableAs(Heading.class)
 public class Version implements BaseSection {
 
     private static final String UNRELEASED_KEYWORD = "unreleased";
+
     private static final int HEADING_LEVEL = 2;
 
     private static final char HYPHEN = '-';
@@ -119,5 +121,20 @@ public class Version implements BaseSection {
 
     public static boolean isVersionLevel(Heading heading) {
         return heading.getLevel() == HEADING_LEVEL;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Version version = (Version) o;
+        return Objects.equals(ref, version.ref) && Objects.equals(date, version.date);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ref, date);
     }
 }

--- a/heylogs-api/src/test/java/_test/Sample.java
+++ b/heylogs-api/src/test/java/_test/Sample.java
@@ -8,6 +8,8 @@ import com.vladsch.flexmark.util.sequence.BasedSequence;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class Sample {
 
@@ -19,6 +21,19 @@ public class Sample {
             if (stream == null) {
                 throw new IllegalArgumentException("Missing resource '" + name + "'");
             }
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+                return PARSER.parseReader(reader);
+            }
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+    }
+
+    public static Document using(Path path) {
+        if (!Files.exists(path)) {
+            throw new IllegalArgumentException("File not found: '" + path + "'");
+        }
+        try (InputStream stream = Files.newInputStream(path)) {
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
                 return PARSER.parseReader(reader);
             }

--- a/heylogs-api/src/test/java/internal/heylogs/GitDiffRuleTest.java
+++ b/heylogs-api/src/test/java/internal/heylogs/GitDiffRuleTest.java
@@ -1,0 +1,297 @@
+package internal.heylogs;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import com.vladsch.flexmark.util.ast.Node;
+import com.vladsch.flexmark.util.misc.Pair;
+import nbbrd.heylogs.Failure;
+import nbbrd.heylogs.Version;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static _test.Sample.using;
+import static nbbrd.heylogs.Nodes.of;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GitDiffRuleTest {
+
+    private GitDiffRule gitDiffRule;
+    private Repository repository;
+    private Git git;
+    private Path changelog;
+
+    private static final LocalDate d20230911 = LocalDate.parse("2023-09-11");
+    private static final LocalDate d20230912 = LocalDate.parse("2023-09-12");
+
+    private static final String CHANGELOG_INITIAL = """
+            # Changelog
+
+            All notable changes to this project will be documented in this file.
+
+            The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+            and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+            ## [0.1.0] - 2023-09-11
+
+            Initial release.
+
+            [0.1.0]: https://example.com/github/repository/releases/tag/0.1.0
+            """;
+
+    private static final String CHANGELOG_UNRELEASED = """
+            # Changelog
+
+            All notable changes to this project will be documented in this file.
+
+            The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+            and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+            ## [unreleased]
+
+            ### Added
+
+            - Some additions.
+
+            ## [0.1.0] - 2023-09-11
+
+            Initial release.
+
+            [unreleased]: https://example.com/github/repository/compare/0.1.0...HEAD
+            [0.1.0]: https://example.com/github/repository/releases/tag/0.1.0
+            """;
+
+    private static final String CHANGELOG_020 = """
+            # Changelog
+
+            All notable changes to this project will be documented in this file.
+
+            The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+            and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+            ## [0.2.0] - 2023-09-12
+
+            ### Added
+
+            - Some additions.
+
+            ## [0.1.0] - 2023-09-11
+
+            Initial release.
+
+            [0.2.0]: https://example.com/github/repository/compare/0.1.0...0.2.0
+            [0.1.0]: https://example.com/github/repository/releases/tag/0.1.0
+            """;
+
+    private static final String CHANGELOG_NO_RELEASE = """
+            # Changelog
+
+            All notable changes to this project will be documented in this file.
+
+            The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+            and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+            ## [unreleased]
+
+            Preparing initial release
+            """;
+
+    @BeforeEach
+    public void setup(@TempDir Path dir) throws Exception {
+        gitDiffRule = new GitDiffRule(dir);
+        changelog = dir.resolve("CHANGELOG.md");
+        repository = FileRepositoryBuilder.create(dir.resolve(".git").toFile());
+        repository.create();
+        git = new Git(repository);
+    }
+
+    private void addAndCommitChangelogMd(String content) throws Exception {
+        Files.writeString(changelog, content);
+        git.add().addFilepattern("CHANGELOG.md").call();
+        git.commit()
+           .setMessage("Creates/updates CHANGELOG.md")
+           .setAuthor(new PersonIdent("Test User", "test@example.com"))
+           .call();
+    }
+
+    @Test
+    public void newUnreleasedSectionIsOk() throws Exception {
+        addAndCommitChangelogMd(CHANGELOG_INITIAL);
+        addAndCommitChangelogMd(CHANGELOG_UNRELEASED);
+        assertThat(of(Node.class).descendants(using(changelog)))
+                .map(gitDiffRule::validate)
+                .filteredOn(Objects::nonNull)
+                .isEmpty();
+    }
+
+    @Test
+    public void newReleaseAddedIsOk() throws Exception {
+        addAndCommitChangelogMd(CHANGELOG_INITIAL);
+        addAndCommitChangelogMd(CHANGELOG_020);
+        assertThat(of(Node.class).descendants(using(changelog)))
+                .map(gitDiffRule::validate)
+                .filteredOn(Objects::nonNull)
+                .isEmpty();
+    }
+
+    @Test
+    public void newReleaseAddedEvenWithNonOKChangesInBetweenIsOk() throws Exception {
+        addAndCommitChangelogMd(CHANGELOG_INITIAL);
+        addAndCommitChangelogMd(CHANGELOG_UNRELEASED);
+        git.checkout().setCreateBranch(true).setName("test").call();
+        createCommit("file.txt", "a");
+        addAndCommitChangelogMd(CHANGELOG_020.replace("additions.", "additions"));
+        createCommit("file.txt", "b");
+        addAndCommitChangelogMd(CHANGELOG_020);
+        createCommit("file.txt", "c");
+
+        gitDiffRule = new GitDiffRule("master", "test");
+        gitDiffRule.setPath(changelog.getParent());
+
+        assertThat(of(Node.class).descendants(using(changelog)))
+                .map(gitDiffRule::validate)
+                .filteredOn(Objects::nonNull)
+                .isEmpty();
+    }
+
+    @Test
+    public void fixInitialReleaseRaisesFailure() throws Exception {
+        addAndCommitChangelogMd(CHANGELOG_INITIAL);
+        addAndCommitChangelogMd(CHANGELOG_020.replace("Initial release.", "_Initial release._"));
+        assertThat(of(Node.class).descendants(using(changelog)))
+                .map(gitDiffRule::validate)
+                .filteredOn(Objects::nonNull)
+                .contains(Failure.builder().rule(gitDiffRule).message("Change in a released version").line(16).column(1).build())
+                .hasSize(1);
+    }
+
+    @Test
+    public void fix020ReleaseRaisesFailure() throws Exception {
+        addAndCommitChangelogMd(CHANGELOG_020);
+        addAndCommitChangelogMd(CHANGELOG_020.replace("additions.", "additions"));
+        assertThat(of(Node.class).descendants(using(changelog)))
+                .map(gitDiffRule::validate)
+                .filteredOn(Objects::nonNull)
+                .contains(Failure.builder().rule(gitDiffRule).message("Change in a released version").line(12).column(1).build())
+                .hasSize(1);
+    }
+
+    @Test
+    public void fix020ReleaseRaisesFailureOneLargerDiff() throws Exception {
+        addAndCommitChangelogMd(CHANGELOG_020);
+        git.checkout().setCreateBranch(true).setName("test").call();
+        createCommit("file.txt", "a");
+        createCommit("file.txt", "b");
+        createCommit("file.txt", "c");
+        addAndCommitChangelogMd(CHANGELOG_020.replace("additions.", "additions"));
+
+        gitDiffRule = new GitDiffRule("master", "test");
+        gitDiffRule.setPath(changelog.getParent());
+
+        assertThat(of(Node.class).descendants(using(changelog)))
+                .map(gitDiffRule::validate)
+                .filteredOn(Objects::nonNull)
+                .contains(Failure.builder().rule(gitDiffRule).message("Change in a released version").line(12).column(1).build())
+                .hasSize(1);
+    }
+
+    private void createCommit(String file, String content) throws Exception {
+        Files.writeString(changelog.getParent().resolve(file), content);
+        git.add().addFilepattern("CHANGELOG.md").call();
+        git.commit()
+           .setMessage("Creates/updates " + content)
+           .setAuthor(new PersonIdent("Test User", "test@example.com"))
+           .call();
+    }
+
+    public static Stream<Arguments> correctChangePairs() {
+        // vs.code and other editors count the line numbers starting by 1, but in this code, everyhting starts with 0
+        // Thus, when inspecting this test manually in an editor, please respect the offset.
+        return Stream.of(
+                Arguments.of(CHANGELOG_INITIAL, CHANGELOG_UNRELEASED, List.of(new Pair(7, 12), new Pair(17, 17))),
+                Arguments.of(CHANGELOG_020, CHANGELOG_020.replace("additions.", "additions"), List.of(new Pair(11, 11))),
+                Arguments.of(CHANGELOG_020, CHANGELOG_020.replace("additions.", "additions.\n\nSome new line"), List.of(new Pair(13, 14)))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void correctChangePairs(String firstChangelog, String secondChangelog, List<Pair<Integer, Integer>> expected) throws Exception {
+        addAndCommitChangelogMd(firstChangelog);
+        addAndCommitChangelogMd(secondChangelog);
+
+        try (RevWalk revWalk = new RevWalk(repository)) {
+            RevCommit newCommit = revWalk.parseCommit(repository.resolve(Constants.HEAD));
+            RevCommit oldCommit = revWalk.parseCommit(newCommit.getParent(0));
+            List<Pair<Integer, Integer>> pairs = GitDiffRule.determineCommitModificationRanges(repository, oldCommit, newCommit);
+            assertThat(pairs).isEqualTo(expected);
+        }
+    }
+
+    @Test
+    public void fromUnreleasedToNewRelease() throws Exception {
+        addAndCommitChangelogMd(CHANGELOG_INITIAL);
+        addAndCommitChangelogMd(CHANGELOG_UNRELEASED);
+        addAndCommitChangelogMd(CHANGELOG_020);
+        assertThat(of(Node.class).descendants(using(changelog)))
+                .map(gitDiffRule::validate)
+                .filteredOn(Objects::nonNull)
+                .isEmpty();
+    }
+
+    @Test
+    public void everyThingOkWhenNoReleaseFound() throws Exception {
+        addAndCommitChangelogMd(CHANGELOG_NO_RELEASE);
+        addAndCommitChangelogMd("""
+                # Changelog
+
+                All notable changes to this project will be documented in this file.
+
+                The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+                and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+                ## [unreleased]
+
+                ### Added
+                                
+                - Something added
+                """);
+        assertThat(of(Node.class).descendants(using(changelog)))
+                .map(gitDiffRule::validate)
+                .filteredOn(Objects::nonNull)
+                .isEmpty();
+    }
+
+    public static Stream<Arguments> versionDeterminedCorrectly() {
+        return Stream.of(
+                Arguments.of(null, CHANGELOG_NO_RELEASE),
+                Arguments.of(Version.of("0.1.0", d20230911), CHANGELOG_INITIAL),
+                Arguments.of(Version.of("0.1.0", d20230911), CHANGELOG_UNRELEASED),
+                Arguments.of(Version.of("0.2.0", d20230912), CHANGELOG_020)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void versionDeterminedCorrectly(Version version, String changelog) throws Exception {
+        assertThat(GitDiffRule.getNewestRelease(changelog.getBytes(StandardCharsets.UTF_8)))
+                .isEqualTo(version);
+    }
+}

--- a/heylogs-api/src/test/resources/tinylog-test.properties
+++ b/heylogs-api/src/test/resources/tinylog-test.properties
@@ -1,0 +1,1 @@
+level@org.eclipse.jgit = WARN

--- a/heylogs-cli/pom.xml
+++ b/heylogs-cli/pom.xml
@@ -66,6 +66,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>tinylog-impl</artifactId>
+            <version>${tinylog.version}</version>
+        </dependency>
 
         <!-- test only -->
         <dependency>

--- a/heylogs-cli/src/main/java/nbbrd/heylogs/cli/CheckCommand.java
+++ b/heylogs-cli/src/main/java/nbbrd/heylogs/cli/CheckCommand.java
@@ -92,7 +92,7 @@ public final class CheckCommand implements Callable<Integer> {
             int failureCount = 0;
             for (Path file : input.getAllFiles(markdown::accept)) {
                 if (isGitDiffEnabled()) {
-                    gitDiffRule.setPath(file.getParent());
+                    gitDiffRule.setPath(file.toAbsolutePath().getParent());
                 }
                 List<Failure> failures = checker.validate(markdown.readDocument(file));
                 checker.formatFailures(writer, markdown.getName(file), failures);

--- a/heylogs-cli/src/main/java/nbbrd/heylogs/cli/GitRangeConverter.java
+++ b/heylogs-cli/src/main/java/nbbrd/heylogs/cli/GitRangeConverter.java
@@ -1,0 +1,16 @@
+package nbbrd.heylogs.cli;
+
+import com.vladsch.flexmark.util.misc.Pair;
+import org.eclipse.jgit.annotations.NonNull;
+import picocli.CommandLine.ITypeConverter;
+
+public class GitRangeConverter implements ITypeConverter<Pair<String, String>> {
+    @Override
+    public Pair<String, String> convert(@NonNull String value)  {
+        String[] ids = value.split("\\.\\.\\.");
+        if (ids.length != 2) {
+            throw new IllegalArgumentException("Invalid commit range format! Expected format is id1...id2.");
+        }
+        return Pair.of(ids[0], ids[1]);
+    }
+}

--- a/heylogs-cli/src/main/resources/tinylog.properties
+++ b/heylogs-cli/src/main/resources/tinylog.properties
@@ -1,0 +1,1 @@
+level@org.eclipse.jgit = WARN

--- a/pom.xml
+++ b/pom.xml
@@ -164,18 +164,20 @@
     </modules>
 
     <profiles>
-        <!-- Base build java8 -->
+        <!-- Base build java-11 -->
         <profile>
-            <id>base-java8</id>
+            <id>base-java-11</id>
             <activation>
                 <property>
-                    <name>!skipBaseJava8</name>
+                    <name>!skipBaseJava17</name>
                 </property>
             </activation>
             <properties>
                 <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-                <maven.compiler.target>1.8</maven.compiler.target>
-                <maven.compiler.source>1.8</maven.compiler.source>
+                <maven.compiler.source>11</maven.compiler.source>
+                <maven.compiler.target>11</maven.compiler.target>
+                <maven.compiler.testSource>17</maven.compiler.testSource>
+                <maven.compiler.testTarget>17</maven.compiler.testTarget>
             </properties>
             <build>
                 <plugins>
@@ -203,6 +205,7 @@
                 <java-service.version>1.7.0</java-service.version>
                 <java-design.version>1.4.0</java-design.version>
                 <picocli.version>4.7.5</picocli.version>
+                <tinylog.version>2.6.2</tinylog.version>
             </properties>
             <dependencyManagement>
                 <dependencies>
@@ -237,6 +240,11 @@
                         <groupId>info.picocli</groupId>
                         <artifactId>picocli-codegen</artifactId>
                         <version>${picocli.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.tinylog</groupId>
+                        <artifactId>tinylog-api</artifactId>
+                        <version>${tinylog.version}</version>
                     </dependency>
                 </dependencies>
             </dependencyManagement>
@@ -273,84 +281,6 @@
                                 <arg>-Aproject=${project.groupId}/${project.artifactId}</arg>
                             </compilerArgs>
                         </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <!-- Run Java8 build with JPMS on JDK9+ -->
-        <profile>
-            <id>java8-with-jpms</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <properties>
-                <!-- Fix NetBeans bug with test packages -->
-                <maven.compiler.target>9</maven.compiler.target>
-                <maven.compiler.source>9</maven.compiler.source>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <executions>
-                            <!-- First: compile all as Java9 -->
-                            <execution>
-                                <id>default-compile</id>
-                                <configuration>
-                                    <release>9</release>
-                                </configuration>
-                            </execution>
-                            <!-- Second: recompile all but module-info as Java8 -->
-                            <execution>
-                                <id>base-compile</id>
-                                <goals>
-                                    <goal>compile</goal>
-                                </goals>
-                                <configuration>
-                                    <source>8</source>
-                                    <target>8</target>
-                                    <excludes>
-                                        <exclude>module-info.java</exclude>
-                                    </excludes>
-                                </configuration>
-                            </execution>
-                            <!-- Third: compile all tests as Java8 -->
-                            <!-- This fails in NetBeans ... -->
-                            <execution>
-                                <id>default-testCompile</id>
-                                <configuration>
-                                    <release>8</release>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <!-- Run Java8 build without JPMS on JDK8 -->
-        <profile>
-            <id>java8-without-jpms</id>
-            <activation>
-                <jdk>1.8</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-compile</id>
-                                <configuration>
-                                    <excludes>
-                                        <exclude>module-info.java</exclude>
-                                    </excludes>
-                                </configuration>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>
@@ -415,7 +345,7 @@
                                         <banCircularDependencies/>
                                         <banDuplicateClasses/>
                                         <enforceBytecodeVersion>
-                                            <maxJdkVersion>8</maxJdkVersion>
+                                            <maxJdkVersion>11</maxJdkVersion>
                                             <ignoredScopes>
                                                 <ignoreScope>test</ignoreScope>
                                             </ignoredScopes>


### PR DESCRIPTION
The `check` feature now contains a check if during an update of the CHANGELOG.md file, areas of released versions are touched.
For instance, a contributor starts a pull request and adds their change to CHANGELOG.md.
Then, the main branch is released.
Now, the PR should move the changelog entry to the new `[unreleased]` section.
Therefore, `heylogs` warns in case there are modifications inside blocks of released versions.
One has to enable this check explicitly by the `-g` command line parameter.

I had to include JGit as dependency. Therefore, the minimum Java requirement is Java 11. I think, this is OK, because Java 17 should be available at most systems.

I use the multiline string feature in the tests, therefore, the tests are Java 17.

Since I wanted to output some debug information, I added `tinylog` as logging framework. The main reason is that `Logger.debug` can be used without any instantiation. - The logging traffic of JGit is routed to tinylog.

Example output:

```text
   112:1  error  Change in a released version  releasechangesfrozen
   253:1  error  Change in a released version  releasechangesfrozen
   400:1  error  Change in a released version  releasechangesfrozen
   427:1  error  Change in a released version  releasechangesfrozen
   507:1  error  Change in a released version  releasechangesfrozen
   554:1  error  Change in a released version  releasechangesfrozen
   738:1  error  Change in a released version  releasechangesfrozen
   881:1  error  Change in a released version  releasechangesfrozen
  1125:1  error  Missing ref link              all-h2-contain-a-version
  1000:1  error  Change in a released version  releasechangesfrozen
```

Due to the way of visiting the Markdown tree, errors in the last block come as very last. I can fix this in a follow-up work, because I think, this issue occurs very seldom - and is just a "UX" issue.