### PR TITLE
Output all separators in error message

### DIFF
--- a/heylogs-api/src/main/java/internal/heylogs/ExtendedRules.java
+++ b/heylogs-api/src/main/java/internal/heylogs/ExtendedRules.java
@@ -129,7 +129,7 @@ public enum ExtendedRules implements Rule {
                 ? Failure
                 .builder()
                 .rule(CONSISTENT_SEPARATOR)
-                .message("Expecting consistent version-date separator " + toUnicode(separators.get(0)) + ", found [" + separators.stream().skip(1).map(ExtendedRules::toUnicode).collect(joining(", ")) + "]")
+                .message("Expecting consistent version-date separator " + toUnicode(separators.get(0)) + ", found " + separators.stream().map(ExtendedRules::toUnicode).collect(joining(", ", "[", "]")))
                 .location(doc)
                 .build()
                 : NO_PROBLEM;


### PR DESCRIPTION
I think, the intention of `[...]` was to list **all** found separators, which I like.

Example

    1:1  error  Expecting consistent version-date separator \u002d, found [\u2013]  consistent-separator

I adapted to code to output all (and also made use of the second and third parameter of `joining` to have the code even more clean.

Refs https://github.com/nbbrd/heylogs/issues/163 (which is not reproducible with heylogs source on my local machine, but with heylogs binary)